### PR TITLE
feat: Add autoscaling operator permissions to engine_role

### DIFF
--- a/charts/workspace/templates/engine_role.yaml
+++ b/charts/workspace/templates/engine_role.yaml
@@ -8,13 +8,15 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources: 
+    resources:
       - pods/status
       - events
-    verbs: 
+    verbs:
       - get
       - list
-      - watch       
+      - watch
+      - create
+      - patch       
   - apiGroups:
       - ""
     resources:
@@ -43,7 +45,9 @@ rules:
     verbs:
       - get
       - list
-      - watch 
+      - watch
+      - update
+      - patch 
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Add necessary Kubernetes RBAC permissions for the autoscaling operator:
- Add 'update' and 'patch' verbs for deployments in apps apiGroup
- Add 'create' and 'patch' verbs for events in core apiGroup

These permissions allow the autoscaling operator to:
1. Scale deployments by updating replica counts
2. Monitor deployment status and pod lifecycle
3. Create Kubernetes events for audit logging

The operator requires these permissions to dynamically scale executor deployments based on cluster workload demands while maintaining proper audit trails through Kubernetes events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)